### PR TITLE
FEAT: implements commitments for InternalNode

### DIFF
--- a/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
@@ -51,6 +51,53 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
     return javaarray;
 }
 
+#[no_mangle]
+pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_update_commitment(env: JNIEnv,
+                                                                                                 _class: JClass<'_>,
+                                                                                                 input: jobjectArray)
+                                                                                                 -> jbyteArray {
+    // input = index, old, new, commitment
+    let length = env.get_array_length(input).unwrap();
+    let len = <usize as TryFrom<jsize>>::try_from(length)
+        .expect("invalid jsize, in jsize => usize conversation");
+
+    if len != 4 {
+        env.throw_new("java/lang/IllegalArgumentException", "Invalid input length")
+           .expect("Failed to throw exception");
+        return std::ptr::null_mut(); // Return null pointer to indicate an error
+    }    
+
+    // TODO: implement update a commitment by commiting
+    // new = H(0, ..., new-old, 0, ...)  (non-zero at index)
+    // commitment + new
+    // Computing new should be optimised.
+    let index_obj = env.get_object_array_element(input, i).expect("Failed to retrieve commitment value");
+    let index: u16 = env.get_int_field(index_obj, "value", "I").expect("Failed to get int field").into();
+
+    let jbarray: jbyteArray = env.get_object_array_element(input, 1).unwrap().cast();
+    let barray = env.convert_byte_array(jbarray).expect("Couldn't read byte array input");
+    let old = Fr::read(barray.as_ref()).unwrap());
+
+    let jbarray: jbyteArray = env.get_object_array_element(input, 2).unwrap().cast();
+    let barray = env.convert_byte_array(jbarray).expect("Couldn't read byte array input");
+    let new = Fr::read(barray.as_ref()).unwrap());
+
+    let jbarray: jbyteArray = env.get_object_array_element(input, 3).unwrap().cast();
+    let barray = env.convert_byte_array(jbarray).expect("Couldn't read byte array input");
+    let old_commitment = Fr::read(barray.as_ref()).unwrap());
+
+    // TODO: write update logic, where poly[index] updates from old to new
+    let mut vec = Vec::with_capacity(256):
+    let poly = LagrangeBasis::new(vec);
+    let crs = CRS::new(256, PEDERSEN_SEED);
+    let result = crs.commit_lagrange_poly(&poly);
+    let mut result_bytes = [0u8; 128];
+    result.write(result_bytes.as_mut()).unwrap();
+    let javaarray = env.byte_array_from_slice(&result_bytes).expect("Couldn't convert to byte array");
+    return javaarray;
+}
+
+
 #[cfg(test)]
 mod tests {
     use std::ops::Deref;

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/Constants.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/Constants.java
@@ -18,4 +18,8 @@ public final class Constants {
     static int getSuffix(Bytes32 key) {
         return key.slice(Constants.STEM_SIZE).toInt(LITTLE_ENDIAN);  // Assumes STEM_SIZE >= 28
     }
+
+    static int getWordAtDepth(Bytes key, int depth) {
+        return key.get(depth) & 0xff;  // cast signed byte to "unsigned" int
+    }
 }

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/EmptyNode.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/EmptyNode.java
@@ -1,16 +1,31 @@
 package org.hyperledger.besu.ethereum.trie.verkle;
 
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.bytes.Bytes;
 
 public class EmptyNode implements VerkleNode{
     int depth;
+    Bytes commitment;
 
     public EmptyNode() {
         this(0);
+        setCommitment(Bytes32.ZERO);
     }
 
     public EmptyNode(int depth) {
         this.depth = depth;
+    }
+
+    public Bytes getCommitment() {
+        return commitment;
+    }
+
+    public void setCommitment() throws Exception {
+        setCommitment(Bytes32.ZERO);
+    }
+
+    public void setCommitment(Bytes commitment) {
+        this.commitment = commitment;
     }
 
     public void insert(Bytes32 key, Bytes32 value) throws Exception {

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/InternalNode.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/InternalNode.java
@@ -5,6 +5,7 @@ import org.apache.tuweni.bytes.Bytes32;
 
 // Eventually add support for persisted Nodes?
 //import org.hyperledger.besu.ethereum.trie.verkle.NodeUpdater;
+import org.hyperledger.besu.nativelib.ipamultipoint.LibIpaMultipoint;
 
 
 public class InternalNode implements VerkleNode {
@@ -12,6 +13,7 @@ public class InternalNode implements VerkleNode {
     int depth;
     Bytes path;
     Bytes commitment;
+    boolean isDirty;
 
     public InternalNode() {
         this(0);
@@ -23,19 +25,45 @@ public class InternalNode implements VerkleNode {
         for (int i = 0; i < Constants.NODE_WIDTH; i++) {
             this.children[i] = new EmptyNode(depth + 1);
         }
+        setCommitment(Bytes32.ZERO);
+    }
+
+    public Bytes getCommitment() {
+        return commitment;
+    }
+
+    public void setCommitment(Bytes commitment) {
+        this.commitment = commitment;
+    }
+
+    public void setCommitment() throws Exception {
+        if ( ! isDirty ) {
+            return;
+        }
+        byte[][] commitments = new byte[Constants.NODE_WIDTH][];
+        for (int i = 0; i < Constants.NODE_WIDTH; i++) {
+            VerkleNode child = children[i];
+            if (child instanceof UnknownNode) {
+                throw new Exception("Cannot commit with UnknownNode child");
+            }
+            child.setCommitment();
+            commitments[i] = child.getCommitment().toArray();
+        }
+        setCommitment(Bytes.wrap(LibIpaMultipoint.commit(commitments)));
+        isDirty = false;
     }
 
     public void insert(Bytes32 key, Bytes32 value) throws Exception {
+        isDirty = true;
         Bytes stem = Constants.getStem(key);
         int suffix = Constants.getSuffix(key);
-        int index = key.get(depth) & 0xff;  // cast signed byte to "unsigned" int
+        int index = Constants.getWordAtDepth(key, depth);
         VerkleNode child = children[index];
         if (child instanceof UnknownNode) {
             throw new Exception("Missing node in stateless");
         } else if (child instanceof InternalNode) {
             InternalNode internalChild = (InternalNode) child;
             internalChild.insert(key, value);
-            return;
         } else if (child instanceof EmptyNode) {
             LeafNode leafNode = new LeafNode(stem, depth + 1);
             leafNode.insert(suffix, value);
@@ -46,12 +74,12 @@ public class InternalNode implements VerkleNode {
                 leafChild.insert(suffix, value);
                 return;
             }
-            int nextWordInExistingKey = leafChild.stem.get(depth + 1) & 0xff;
+            int nextWordInExistingKey = Constants.getWordAtDepth(leafChild.stem, depth + 1);
             InternalNode newBranch = new InternalNode(depth + 1);
             children[index] = newBranch;
             newBranch.children[nextWordInExistingKey] = leafChild;
             leafChild.depth += 1;
-            int nextWordInInsertedKey = stem.get(depth + 1) & 0xff;
+            int nextWordInInsertedKey = Constants.getWordAtDepth(stem, depth + 1);
             if (nextWordInInsertedKey == nextWordInExistingKey) {
                 newBranch.insert(key, value);
                 return;
@@ -67,4 +95,4 @@ public class InternalNode implements VerkleNode {
     public void insertMany(Bytes stem, Bytes32[] values) {
         throw new UnsupportedOperationException("Unimplemented method 'insertMany'");
     }
-}    
+}

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/LeafNode.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/LeafNode.java
@@ -1,20 +1,41 @@
 package org.hyperledger.besu.ethereum.trie.verkle;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class LeafNode implements VerkleNode{
     Bytes stem;
     int depth;
-    Map<Integer, Bytes> values;  // TODO: use extension + suffix structure instead.
+    Bytes commitment;
+    Bytes[] subCommitments;  // C1, C2 in EIP
+    Bytes32[] values;
+    boolean isDirty;
 
     public LeafNode(Bytes stem, int depth) {
         this.stem = stem;
         this.depth = depth;
-        this.values = new HashMap<>(Constants.NODE_WIDTH);
+        values = new Bytes32[Constants.NODE_WIDTH];
+        for (int i = 0; i < Constants.NODE_WIDTH; i++) {
+            values[i] = null;
+        }
+        isDirty = false;
+    }
+
+    public Bytes getCommitment() {
+        return commitment;
+    }
+
+    public void setCommitment(Bytes commitment) {
+        this.commitment = commitment;
+    }
+
+    public void setCommitment() {
+        // TODO: implement this method
+        // H(1, stem, C1, C2, 0, ...)
+        // C1 = commitment of values' first half
+        // C2 = commitment of values' second half
+        // Values take 2 slots, with lower bits are padded with a single 1 (add 2^128).
+        this.commitment = Bytes32.ZERO;
     }
 
     public void insert(Bytes32 key, Bytes32 value) throws Exception {
@@ -27,6 +48,6 @@ public class LeafNode implements VerkleNode{
     }
 
     public void insert(int suffix, Bytes32 value) throws Exception {
-        values.put(suffix, value);
+        values[suffix] = value;
     }
 }

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/UnknownNode.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/UnknownNode.java
@@ -1,9 +1,11 @@
 package org.hyperledger.besu.ethereum.trie.verkle;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class UnknownNode implements VerkleNode {
     int depth;
+    Bytes commitment;
 
     public UnknownNode() {
         this(0);
@@ -11,6 +13,14 @@ public class UnknownNode implements VerkleNode {
 
     public UnknownNode(int depth) {
         this.depth = depth;
+    }
+
+    public Bytes getCommitment() throws Exception {
+        throw new Exception("Unknown commitment for UnknownNode");
+    }
+
+    public void setCommitment() throws Exception {
+        throw new Exception("Unknown commitment for UnknownNode");
     }
 
     public void insert(Bytes32 key, Bytes32 value) throws Exception {

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleNode.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/VerkleNode.java
@@ -1,14 +1,17 @@
 package org.hyperledger.besu.ethereum.trie.verkle;
 
 import org.apache.tuweni.bytes.Bytes32;
-// import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes;
 // import org.hyperledger.besu.ethereum.trie.verkle.NodeUpdater;
 
 
 public interface VerkleNode {
+    Bytes getCommitment() throws Exception;
+    void setCommitment() throws Exception;
+
     // Insert or Update value into the tree
     void insert(Bytes32 key, Bytes32 value) throws Exception;
-
+    
     // Delete a leaf with the given key
     // boolean delete(byte[] key, NodeUpdater updater) throws Exception;
 

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -50,4 +50,5 @@ public class LibIpaMultipoint {
    * @return the coordinates of the projection of the polynomial on the curve
    */
   public static native byte[] commit(byte[][] input);
+  public static native byte[] update_commitment();
 }

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/InternalNodeTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/InternalNodeTest.java
@@ -74,4 +74,33 @@ public class InternalNodeTest {
         assertThat(node.children[17]).isInstanceOf(LeafNode.class);
         assertThat(node.children[255]).isInstanceOf(LeafNode.class);
     }
+
+    @Test
+    public void testDivergentAtLowDepth() throws Exception {
+        InternalNode root = new InternalNode();
+        Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+        Bytes32 key2 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccdd00ff");
+        Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+        Bytes32 key3 = Bytes32.fromHexString("0x00112233445566778899aabbccddee0000112233445566778899aabbccddeeff");
+        Bytes32 value3 = Bytes32.fromHexString("0x0010000000000000000000000000000000000000000000000000000000000000");
+        root.insert(key1, value1);
+        root.insert(key2, value2);
+        root.insert(key3, value3);
+        InternalNode cursor = root;
+        for (int i = 0; i < 30; i++) {
+            int index = Constants.getWordAtDepth(key1, i);
+            assertThat(cursor.children[index]).isInstanceOf(InternalNode.class);
+            cursor = (InternalNode) cursor.children[index];
+        }
+        assertThat(cursor.children[0]).isInstanceOf(LeafNode.class);
+        assertThat(cursor.children[238]).isInstanceOf(LeafNode.class);
+        cursor = root;
+        for (int i = 0; i < 15; i++) {
+            int index = Constants.getWordAtDepth(key3, i);
+            assertThat(cursor.children[index]).isInstanceOf(InternalNode.class);
+            cursor = (InternalNode) cursor.children[index];
+        }
+        assertThat(cursor.children[0]).isInstanceOf(LeafNode.class);
+    }
 }


### PR DESCRIPTION
Start adding support for commitments in the Trie.
InternalNode commits to its children's commitments. On inserting a new element in the Trie, the affected Nodes become dirty. On setCommitment, it recomputes the commitment if isDirty.

Also, setup commitments for LeafNodes, but remains to implement. Setup update_commitment in the IpaMultipoint JNI, also needs implementation.