### PR TITLE
[WIP] init: banderwagon migration

### DIFF
--- a/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
+++ b/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
@@ -22,10 +22,13 @@ repository = "https://github.com/hyperledger/besu-native"
 edition = "2018"
 
 [dependencies]
-ipa-multipoint = { git = "https://github.com/crate-crypto/ipa_multipoint", rev = "d5590ef5" }
-bandersnatch = "0.1.1"
+ipa-multipoint = { git = "https://github.com/crate-crypto/ipa_multipoint", branch = "banderwagon_migration" }
+banderwagon = { git = "https://github.com/crate-crypto/banderwagon" }
+ark-ff = { version = "^0.3.0", default-features = false }
+ark-ec = { version = "^0.3.0", default-features = false }
+ark-serialize = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
 jni = { version = "0.19.0", features = ["invocation"] } # We use invocation in tests.
-ark-ff = "0.3.0"
 hex = "0.4.3"
 
 [lib]

--- a/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
+++ b/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
@@ -24,6 +24,7 @@ edition = "2018"
 [dependencies]
 ipa-multipoint = { git = "https://github.com/crate-crypto/ipa_multipoint", branch = "banderwagon_migration" }
 banderwagon = { git = "https://github.com/crate-crypto/banderwagon" }
+bandersnatch = "0.1.1"
 ark-ff = { version = "^0.3.0", default-features = false }
 ark-ec = { version = "^0.3.0", default-features = false }
 ark-serialize = { version = "^0.3.0", default-features = false }

--- a/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
@@ -16,9 +16,9 @@ use std::convert::TryFrom;
 use std::ops::Add;
 use ark_ff::bytes::{FromBytes, ToBytes};
 use ark_ff::{Zero};
-use bandersnatch::{Fr, EdwardsProjective};
+use banderwagon::{ Element};
 use ipa_multipoint::lagrange_basis::LagrangeBasis;
-use ipa_multipoint::multiproof::CRS;
+use ipa_multipoint::crs::CRS;
 use jni::JNIEnv;
 use jni::objects::JClass;
 use jni::sys::{jbyteArray, jobjectArray, jsize};
@@ -49,7 +49,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
     let crs = CRS::new(256, PEDERSEN_SEED);
     let result = crs.commit_lagrange_poly(&poly);
     let mut result_bytes = [0u8; 128];
-    result.write(result_bytes.as_mut()).unwrap();
+    result.to_bytes();
     let javaarray = env.byte_array_from_slice(&result_bytes).expect("Couldn't convert to byte array");
     return javaarray;
 }
@@ -86,7 +86,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
 
     let jbarray: jbyteArray = env.get_object_array_element(input, 3).unwrap().cast();
     let barray = env.convert_byte_array(jbarray).expect("Couldn't read byte array input");
-    let old_commitment = EdwardsProjective::read(barray.as_ref()).unwrap();
+    let old_commitment = Fr::read(barray.as_ref()).unwrap();
 
     let delta = new - old;
     let mut vec = vec![Fr::zero(); 256];


### PR DESCRIPTION
WIP draft PR for banderwagon migration, these are some of the following changes I could think of:

- Changing the way Java input arrays for commitments are read
- `EdwardsProjective` gets deprecated in Banderwagon, can go through this commit https://github.com/crate-crypto/rust-verkle/commit/1d2ca08f49d01db6cb31689b40f96823ae9ae2b6
- `add` function for `old_commitments` and `new_commitments` are deprecated for `banderwagon::Fr` unlike  `bandersnatch::Fr`
- `multiproofs:crs` for CRS has it's own module in `ipa_multipoint` for `banderwagon_migration` branch (currently being used in `rust-verkle`.

Looking for the alternatives 

Some good resources:
- [banderwagon/element](https://github.com/crate-crypto/banderwagon/blob/master/src/element.rs)
- [ipa_multipoint/banderwagon_migration/src/crs](https://github.com/crate-crypto/ipa_multipoint/blob/banderwagon_migration/src/crs.rs)