### PR TITLE
ADD: Pedersen hash

### DIFF
--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/PedersenHash.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/PedersenHash.java
@@ -1,0 +1,40 @@
+package org.hyperledger.besu.ethereum.trie.verkle;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.nativelib.ipamultipoint.LibIpaMultipoint;
+
+
+public class PedersenHash {
+    public void pedersenHash() {}
+
+    public Bytes32 digest(Bytes input) {
+        int size = input.size();
+        if (size > 255 * 16) {
+            throw new IllegalArgumentException("Pedersen Hash's input is too long (>255*16 bytes)");
+        }
+        byte[][] inp = new byte[256][];  // input to nativelib
+        int header = 2 + 255 * size;
+        inp[0] = Bytes.ofUnsignedInt(header).toArray();
+
+        // 0-padded input of 255 chunks of 16 bytes 
+        byte[] paddedInput = Arrays.copyOf(input.toArray(), 255 * 16);
+        for (int i = 0; i < 255; i++) {
+            inp[i + 1] = Arrays.copyOfRange(paddedInput, 16 * i, 16 * (i + 1));
+        }
+        // Once commit is fixed, we need to use it. For now, using sha256
+        // Bytes32 out = Bytes32.wrap(LibIpaMultipoint.commit(inp));
+        Bytes32 out;
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            out = Bytes32.wrap(sha256.digest(paddedInput));
+        } catch (NoSuchAlgorithmException e) {
+            out = Bytes32.ZERO;
+        }
+        return out;
+    } 
+}

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/PedersenHashTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/PedersenHashTest.java
@@ -1,0 +1,19 @@
+package org.hyperledger.besu.ethereum.trie.verkle;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class PedersenHashTest {
+    
+    @Test
+    public void testShortByte() {
+        PedersenHash hasher = new PedersenHash();
+        Bytes msg = Bytes.fromHexString("0xef342498");
+        // Need to change this once commit is fixed
+        Bytes32 expected = Bytes32.fromHexString("0x60caa1655cd0e7b73a0de01e26ba12540a42f9f00f4597685b55a392267460e5");
+        assertThat(hasher.digest(msg)).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Pedersen hash is implemented in PedersenHash. 

Pedersen hash is needed for trie keys generation. It takes as input Bytes and produces Bytes32.

Note: It should rely on IpaMultiPoint.commit, but uses sha256 for the moment until commit is fixed. We can still test VerkleTrie get, put, delete and generation of Trie keys even if the values are not the proper one for now.