### PR TITLE
pedersen hash rust JNI implementation

### DIFF
--- a/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
@@ -84,7 +84,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
 /// The result is a 256 bit hash
 /// TODO: make the parameters prettier
 fn pedersen_hash(address_input : &Vec<u8>, trie_index_input : &Vec<u8>) -> [u8; 32] {
-    let constant = Fr::from(2u128 + 256u128*64u128);
+    let constant = Fr::from(2u128 + 256u128*64u128); // Hardcoded constant
 
     let address_reference_to_vec: &Vec<u8> = &address_input;
     let address: &[u8] = &*address_reference_to_vec;

--- a/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
@@ -1,6 +1,3 @@
-use core::ascii;
-use std::array;
-use std::ascii::AsciiExt;
 /*
  * Copyright Besu Contributors
  *
@@ -16,20 +13,19 @@ use std::ascii::AsciiExt;
  * SPDX-License-Identifier: Apache-2.0
  */
 use std::convert::TryFrom;
-use std::ops::Add;
-use std::str::FromStr;
-use ark_ff::bytes::{FromBytes, ToBytes};
+
+
+
 use ark_ff::{Zero, PrimeField};
 use banderwagon::{Fr, Element, multi_scalar_mul};
-use hex::encode;
+
 use ipa_multipoint::lagrange_basis::LagrangeBasis;
 use ipa_multipoint::crs::CRS;
 use jni::JNIEnv;
 use jni::objects::JClass;
 use jni::sys::{jbyteArray, jobjectArray, jsize};
-// use std::ascii::*;
-use core::ascii::*;
-use hex::FromHex;
+
+
 
 #[no_mangle]
 pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_pedersenHash(
@@ -38,67 +34,43 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
     input: jbyteArray,
 ) -> jbyteArray {
     // First, we have to get the byte[] out of java.
-    let mut ascii_bytes = env.convert_byte_array(input).unwrap();
-    let mut fixed_size_array: [u8; 128] = [0; 128];
+    let ascii_bytes = env.convert_byte_array(input).unwrap();
+    let mut helper_array: [u8; 128] = [0; 128];
 
-    fixed_size_array.copy_from_slice(&ascii_bytes);
-
-    // Now we create an address from this.
-    let mut address32 = [0u8; 32];
+    helper_array.copy_from_slice(&ascii_bytes);
 
 
     let mut merged_values: Vec<u8> = Vec::new();
-    // Iterate over pairs of elements and merge them into u8 values
-    for chunk in fixed_size_array.chunks(2) {
+    // Iterate over pairs of elements and merge them into u8 values so we can use them for the pedersen hash.
+    for chunk in helper_array.chunks(2) {
         if chunk.len() == 2 {
             let merged_byte = (chunk[0] << 4) | (chunk[1] & 0x0F);
             merged_values.push(merged_byte);
         }
     }
 
+    // Now we create the address and trie index variables.
+    let mut address32 = [0u8; 32];
     address32.copy_from_slice(&merged_values[0..32]);
-
     let mut trie_index= [0u8; 32];
-
     trie_index.copy_from_slice(&merged_values[32..64]);
 
+    // Now we compute the pedersen hash
     let mut result = pedersen_hash(&address32.to_vec(), &trie_index.to_vec());
 
-    // Turn result into [u8; 32] to [u8; 64]
 
-    let mut bra = [0u8; 32];
-
-    let mut ewq = Vec::from_hex("946352acd92aba2884d2b8746f44ae5fa1f61cc424af5c1a74c5c688862e2e48").unwrap();
-
-
-    // let qwe = "946352acd92aba2884d2b8746f44ae5fa1f61cc424af5c1a74c5c688862e2e48";
-    // for i in &str::chars(qwe) {
-    //     bra.push(i.to_digit(16).unwrap() as u8);
-    // }
-    // let q = "946352acd92aba2884d2b8746f44ae5fa1f61cc424af5c1a74c5c688862e2e48".as_bytes().to_vec();
-
-    // bra.copy_from_slice(&q);
-
-    // for
-    // result.clone().to_ascii_lowercase();
-    // let wqe = String::from_utf8(result.clone().to_ascii_lowercase()).unwrap();
-
-    let ew = result.clone();
-    
-    let mut re = String::from("");
+    // TODO: make this prettier, this is very ugly.
+    let mut build_string = String::from("");
     for i in 0..32 {
-        let mut hex_string1 = format!("{:02x}", ew[i]);
-        re = format!("{}{}", &re, hex_string1.clone());
+        let hex_string = format!("{:02x}", &result[i]);
+        build_string = format!("{}{}", &build_string, hex_string.clone());
     }
-
+    // TODO: remove next 3 lines, it's for testing purposes.
     // let mut str1 = "946352acd92aba2884d2b8746f44ae5fa1f61cc424af5c1a74c5c688862e2e48";
     // let mut str2 = re.as_str();
     // assert_eq!(str1, re.as_str());
-    let iw = turn_str_to_bytes(re.as_str());
-
-    // assert_eq!(result.clone(), ewq.clone().as_slice());
-
-    let output = env.byte_array_from_slice(&iw).unwrap();
+    let result_array = turn_str_to_bytes(build_string.as_str());
+    let output = env.byte_array_from_slice(&result_array).unwrap();
     output
 }
 
@@ -110,6 +82,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
 /// trie_index_low = first 16 bytes of the trie index
 /// trie_index_high = last 16 bytes of the trie index
 /// The result is a 256 bit hash
+/// TODO: make the parameters prettier
 fn pedersen_hash(address_input : &Vec<u8>, trie_index_input : &Vec<u8>) -> [u8; 32] {
     let constant = Fr::from(2u128 + 256u128*64u128);
 
@@ -119,6 +92,7 @@ fn pedersen_hash(address_input : &Vec<u8>, trie_index_input : &Vec<u8>) -> [u8; 
     let trie_index_reference_to_vec: &Vec<u8> = &trie_index_input;
     let trie_index: &[u8] = &*trie_index_reference_to_vec;
 
+    // TODO: remove next 2 lines, it's used for testing.
     // let address = "200000000000000000000000b794f5ea0ba39494ce839613fffba74279579268".as_bytes();
     // let trie_index = "2000000000000000000000000000000000000000000000000000000000000001".as_bytes();
 
@@ -130,25 +104,31 @@ fn pedersen_hash(address_input : &Vec<u8>, trie_index_input : &Vec<u8>) -> [u8; 
 
     let trie_index_high = Fr::from_le_bytes_mod_order(&trie_index[16..32]);
 
+    // Create a vector with the scalars. The first one is the constant, the rest are the values of the address and trie index
     let scalars = vec![constant, address_low.clone(), address_high.clone(), trie_index_low.clone(), trie_index_high.clone()];
 
+    // Generate the CRS
     let bases = CRS::new(5, "eth_verkle_oct_2021".as_bytes());
 
     // Compute the multi scalar multiplication. The result is a point in the banderwagon group.
     let mut result = multi_scalar_mul(&bases.G, &scalars).to_bytes();
+
+    // Reverse the result to get the correct order of the bytes.
     result.reverse();
     return result;
 }
 
+/// Helper function for Java JNI.
+/// It receives a hexadecimal string and returns a [u8; 64] array
+/// where each byte is the hexadecimal value of the letter in the string.
+/// This is needed because of the Rust and Java interoperability.
 fn turn_str_to_bytes(hex_string: &str) -> [u8; 64] {
     // Create a vector to store the u8 integers
     let mut u8_integers: Vec<u8> = Vec::new();
 
     // Iterate over each character in the hexadecimal string
-
     for hex_char in hex_string.chars() {
-        // Ensure the character is a valid hexadecimal digit
-        let mut hex_val = hex_char as u8;
+        let hex_val = hex_char as u8;
         u8_integers.push(hex_val);
     }
 
@@ -177,7 +157,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
     let length = env.get_array_length(input).unwrap();
     let len = <usize as TryFrom<jsize>>::try_from(length)
         .expect("invalid jsize, in jsize => usize conversation");
-    let mut vec = Vec::with_capacity(len);
+    let vec = Vec::with_capacity(len);
     
     if len != 4 {
         env.throw_new("java/lang/IllegalArgumentException", "Invalid input length")
@@ -213,7 +193,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
     let poly = LagrangeBasis::new(vec);
     let crs = CRS::new(256, PEDERSEN_SEED);
     let result = crs.commit_lagrange_poly(&poly);
-    let mut result_bytes = [0u8; 128];
+    let result_bytes = [0u8; 128];
     result.to_bytes();
     let javaarray = env.byte_array_from_slice(&result_bytes).expect("Couldn't convert to byte array");
     return javaarray;
@@ -238,15 +218,15 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
 
     let index_obj = env.get_object_array_element(input, 0).expect("Failed to retrieve commitment value");
     let j_value = env.get_field(index_obj, "value", "I").expect("Failed to get field value");
-    let index = j_value.i().expect("Expected int value") as u16;
+    let _index = j_value.i().expect("Expected int value") as u16;
 
     let jbarray: jbyteArray = env.get_object_array_element(input, 1).unwrap().cast();
     let barray = env.convert_byte_array(jbarray).expect("Couldn't read byte array input");
-    let old  = Element::from_bytes(&[barray[1]]).unwrap();
+    let _old  = Element::from_bytes(&[barray[1]]).unwrap();
 
     let jbarray: jbyteArray = env.get_object_array_element(input, 2).unwrap().cast();
     let barray = env.convert_byte_array(jbarray).expect("Couldn't read byte array input");
-    let new = Element::from_bytes(&[barray[2]]).unwrap();
+    let _new = Element::from_bytes(&[barray[2]]).unwrap();
 
 
     let jbarray: jbyteArray = env.get_object_array_element(input, 3).unwrap().cast();
@@ -262,7 +242,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
     result = banderwagon::multi_scalar_mul(&[new_commitment],&[vec[0]]);
     
 
-    let mut result_bytes = [0u8; 128];
+    let result_bytes = [0u8; 128];
     result.to_bytes();
 
     let javaarray = env.byte_array_from_slice(&result_bytes).expect("Couldn't convert to byte array");

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -16,6 +16,7 @@
 package org.hyperledger.besu.nativelib.ipamultipoint;
 
 import com.sun.jna.Native;
+import org.apache.tuweni.bytes.Bytes32;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,4 +52,5 @@ public class LibIpaMultipoint {
    */
   public static native byte[] commit(byte[][] input);
   public static native byte[] update_commitment();
+  public static native byte[] pedersenHash(byte[] input);
 }

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -52,5 +52,11 @@ public class LibIpaMultipoint {
    */
   public static native byte[] commit(byte[][] input);
   public static native byte[] update_commitment();
+
+  /**
+   * Pedersen hash as specified in https://notes.ethereum.org/@vbuterin/verkle_tree_eip
+   * @param input Expects 64byte value as input encoded as byte[] e.g. "0x000..." <-> [48,48,48...] (48 is 0 in ASCII)
+   * @return 32bytes as byte[]  "0x000..." <-> [48,48,48...] (48 is 0 in ASCII)
+   */
   public static native byte[] pedersenHash(byte[] input);
 }

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
@@ -16,31 +16,32 @@
 package org.hyperledger.besu.nativelib.ipa_multipoint;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.nativelib.ipamultipoint.LibIpaMultipoint;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class LibIpaMultipointTest {
-
   @Test
-  public void testCallLibrary() {
-    Bytes input = Bytes.fromHexString("0x0cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec840cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec840cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec840cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec84");
-    byte[] result = LibIpaMultipoint.commit(new byte[][]{input.toArrayUnsafe(), input.toArrayUnsafe(), input.toArrayUnsafe(), input.toArrayUnsafe()});
-    assertThat(Bytes.wrap(result)).isEqualTo(Bytes.fromHexString("0xc70a1e0077e1fff6702f2bde0cccf1bf5915d4c5ab73c33ea5e75b6f703d2346aa7aa373cd07fdf684282c11a7f7623b6e67d2b65862ca0011e2415726c87415d07ada26afff5e6be8066c57228e78399cb3af7490f4de739eef0191907eca0d9ba47aec3457f0fab28324061ec27508e29b067acb3a97fbb43dea61a376f73b"));
-  }
+  public void testPedersenHash() {
+    // I've put 2 in front for testing reason, real values will rarely start with 2.
+    Bytes32 address = Bytes32.fromHexString("0x200000000000000000000000b794f5ea0ba39494ce839613fffba74279579268");
+    Bytes32 trieIndex = Bytes32.fromHexString("0x2000000000000000000000000000000000000000000000000000000000000001");
+    Bytes total = Bytes.wrap(address,trieIndex);
+    String totalString = total.toHexString().substring(2); // subtract leading "0x"
+    byte[] totalStringBytes = totalString.getBytes();
+    byte[] result = LibIpaMultipoint.pedersenHash(totalStringBytes);
 
-  @Test
-  public void testCallLibraryWithManyElements() {
-    Bytes input = Bytes.fromHexString("0x0cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec840cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec840cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec840cfe3041fb6512c87922e2146c8308b372f3bf967f889e69ad116ce7c7ec84");
-    List<byte[]> params = new ArrayList<>();
-    for (int i = 0 ; i < 128; i++) {
-      params.add(input.toArrayUnsafe());
-    }
-    byte[] result = LibIpaMultipoint.commit(params.toArray(new byte[][]{}));
-    assertThat(Bytes.wrap(result)).isEqualTo(Bytes.fromHexString("0x2754861a27f6a3c497d191a659c5969c079d48b24b14e51fdf4a547c6212730871be4e9e05ca94c3a59765e698ea27a6ce5e8ebaaff5ee4b4d692933689bad5980af30ba045d8817819133fa2dbe1a287275b5e95929e0bd3aedacc39759aa57bd8c8b67fb06a45e661923f3d003cc523ce9bec2cee009bbaa30b46216b1d76f"));
+    // expected value
+    Bytes total2 = Bytes32.fromHexString("0xbc27c15f46d538933a54f7cb793ab2310ee0f50996e3bac22c0acdc05715e95c");
+    String totalString2 = total2.toHexString().substring(2); // subtract leading "0x"
+    byte[] totalStringBytes2 = totalString2.getBytes();
+    assertThat(result).isEqualTo(totalStringBytes2);
+    System.out.println(Arrays.toString(result));
   }
 }


### PR DESCRIPTION
Pedersen hash working with byte[] values. This is because of the nature of rust JNI crate. This can be maybe improved over the time, but it's working like this for now


Pedersen hash expects 64 byte value per specs (32 bytes for address and 32 bytes for trie_index). Take a look at the `public void testPedersenHash()` in order to correctly call it.