### PR TITLE
Implement CommitVisitor

### DIFF
--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/BranchNode.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/BranchNode.java
@@ -111,11 +111,6 @@ public class BranchNode<V> implements Node<V> {
     }
 
     @Override
-    public Optional<V> getValue() {
-        return Optional.empty();
-    }
-
-    @Override
     public List<Node<V>> getChildren() {
         return children;
     }

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/CommitVisitor.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/CommitVisitor.java
@@ -50,7 +50,8 @@ public class CommitVisitor<V> implements PathNodeVisitor<V> {
         if (!leafNode.isDirty()) {
             return leafNode;
         }
-        nodeUpdater.store(location, null, valueSerialiser.apply(leafNode.getValue().get()));
+        Bytes extendedLocation = Bytes.concatenate(location, leafNode.getPath());
+        nodeUpdater.store(extendedLocation, null, valueSerialiser.apply(leafNode.getValue().get()));
         return leafNode;
     }
 

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/CommitVisitor.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/CommitVisitor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.verkle;
+
+import java.util.function.Function;
+
+import org.apache.tuweni.bytes.Bytes;
+
+
+public class CommitVisitor<V> implements PathNodeVisitor<V> {
+
+    protected final NodeUpdater nodeUpdater;
+    protected final Function<V, Bytes> valueSerialiser;
+
+    public CommitVisitor(final NodeUpdater nodeUpdater, final Function<V, Bytes> valueSerialiser) {
+        this.nodeUpdater = nodeUpdater;
+        this.valueSerialiser = valueSerialiser;
+    }
+
+    @Override
+    public Node<V> visit(final BranchNode<V> branchNode, final Bytes location) {
+        if (!branchNode.isDirty()) {
+            return branchNode;
+        }
+        Bytes extendedLocation = Bytes.concatenate(location, branchNode.getPath());
+
+        for (int i = 0; i < branchNode.maxChild(); ++i) {
+            Bytes index = Bytes.of(i);
+            final Node<V> child = branchNode.child((byte) i);
+            child.accept(this, Bytes.concatenate(extendedLocation, index));
+        }
+        nodeUpdater.store(location, null, (Bytes) branchNode.getHash().get());
+        return branchNode;
+    }
+
+    @Override
+    public Node<V> visit(final LeafNode<V> leafNode, final Bytes location) {
+        if (!leafNode.isDirty()) {
+            return leafNode;
+        }
+        nodeUpdater.store(location, null, valueSerialiser.apply(leafNode.getValue().get()));
+        return leafNode;
+    }
+
+    @Override
+    public Node<V> visit(final NullNode<V> nullNode, final Bytes location) {
+        return nullNode;
+    }
+}

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrie.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrie.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.trie.verkle;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -24,6 +25,7 @@ import org.apache.tuweni.bytes.Bytes32;
 
 public class SimpleVerkleTrie<K extends Bytes, V extends Bytes> implements VerkleTrie<K, V> {
     private Node<V> root;
+    final private Function<V, Bytes> valueSerialiser = a -> (Bytes) a;
 
     public SimpleVerkleTrie() {
         this.root = NullNode.instance();
@@ -65,6 +67,7 @@ public class SimpleVerkleTrie<K extends Bytes, V extends Bytes> implements Verkl
 
     @Override
     public void commit(final NodeUpdater nodeUpdater) {
-        // Nothing to do here
+        root = root.accept(new HashVisitor<V>(), root.getPath());
+        root = root.accept(new CommitVisitor<V>(nodeUpdater, valueSerialiser), Bytes.EMPTY);
     }
 }

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/CommitVisitorTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/CommitVisitorTest.java
@@ -1,0 +1,46 @@
+package org.hyperledger.besu.ethereum.trie.verkle;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class CommitVisitorTest {
+    
+    @Test
+    public void testEmptyTrie() {
+        NodeUpdaterMock<Bytes> nodeUpdater = new NodeUpdaterMock<Bytes>();
+        SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+        trie.commit(nodeUpdater);
+        assertThat(nodeUpdater.storage.isEmpty());
+    }
+
+    @Test
+    public void testOneValue() {
+        NodeUpdaterMock<Bytes> nodeUpdater = new NodeUpdaterMock<Bytes>();
+        SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+        Bytes32 key = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        Bytes32 value = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+        trie.put(key, value);
+        trie.commit(nodeUpdater);
+        assertThat(nodeUpdater.storage.get(key)).isEqualTo((Bytes) value);
+    }
+
+    @Test
+    public void testTwoValuesAtSameStem() throws Exception {
+        NodeUpdaterMock<Bytes> nodeUpdater = new NodeUpdaterMock<Bytes>();
+        SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+        Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+        Bytes32 key2 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddee00");
+        Bytes32 value2 = Bytes32.fromHexString("0x0100000000000000000000000000000000000000000000000000000000000000");
+        trie.put(key1, value1);
+        trie.put(key2, value2);
+        trie.commit(nodeUpdater);
+        System.out.println(String.format("Keys: %s", nodeUpdater.storage.keySet()));
+        assertThat(nodeUpdater.storage.get(key1)).isEqualTo((Bytes) value1);
+        assertThat(nodeUpdater.storage.get(key2)).isEqualTo((Bytes) value2);
+    }
+
+}

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/NodeUpdaterMock.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/NodeUpdaterMock.java
@@ -1,0 +1,23 @@
+package org.hyperledger.besu.ethereum.trie.verkle;
+
+import java.util.HashMap;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class NodeUpdaterMock<V extends Bytes> implements NodeUpdater {
+
+    public HashMap<Bytes, Bytes> storage;
+    
+    public NodeUpdaterMock() {
+        this.storage = new HashMap<Bytes, Bytes>();
+    }
+
+    public NodeUpdaterMock(HashMap<Bytes, Bytes> storage) {
+        this.storage = storage;
+    }
+
+    public void store(Bytes location, Bytes32 hash, Bytes value) {
+        storage.put(location, value);
+    }
+}


### PR DESCRIPTION
Implement CommitVisitor

CommitVisitor walks the trie and saves node data to the database.
It relies on NodeUpdater for writes. In tests, we mock the database with a HashMap.
It also relies on a valueSerializer function to serialise node data to Bytes for the value field.