### PR TITLE
ENH: RemoveVisitor with Flattening extensions

### DIFF
--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/RemoveVisitor.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/ethereum/trie/verkle/RemoveVisitor.java
@@ -1,9 +1,26 @@
 package org.hyperledger.besu.ethereum.trie.verkle;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.tuweni.bytes.Bytes;
 
 public class RemoveVisitor<V> implements PathNodeVisitor<V> {
-    private final Node<V> NULL_NODE_RESULT = NullNode.instance();
+    private final Node<V> NULL_NODE = NullNode.instance();
+
+    protected Node<V> mergeSingleBranching(
+            final Node<V> node,
+            final Bytes commonPath,
+            final Bytes pathSuffix, 
+            final Bytes nodeSuffix) {
+        final Node<V> updatedNode = node.replacePath(nodeSuffix.slice(1));
+        // Should also add byte to location
+        BranchNode<V> newBranchNode = new BranchNode<V>(node.getLocation(), commonPath);
+        newBranchNode.replaceChild(nodeSuffix.get(0), updatedNode);
+        final Node<V> insertedNode = newBranchNode.child(pathSuffix.get(0)).accept(this, pathSuffix.slice(1));
+        newBranchNode.replaceChild(pathSuffix.get(0), insertedNode);
+        return newBranchNode;
+    }
 
     @Override
     public Node<V> visit(BranchNode<V> branchNode, Bytes path) {
@@ -14,9 +31,10 @@ public class RemoveVisitor<V> implements PathNodeVisitor<V> {
         }
         final Bytes pathSuffix = path.slice(commonPath.size());
         final byte childIndex = pathSuffix.get(0);
-        final Node<V> chilNode = branchNode.child(childIndex).accept(this, pathSuffix.slice(1));
-        branchNode.replaceChild(childIndex, chilNode);
-        return branchNode;
+        final Node<V> childNode = branchNode.child(childIndex).accept(this, pathSuffix.slice(1));
+        branchNode.replaceChild(childIndex, childNode);
+        Node<V> resultNode = maybeFlatten(branchNode);
+        return resultNode;
     }
 
     @Override
@@ -26,12 +44,36 @@ public class RemoveVisitor<V> implements PathNodeVisitor<V> {
         if (commonPath.compareTo(nodePath) != 0) {
             return leafNode;
         }
-        return NULL_NODE_RESULT;
+        return NULL_NODE;
     }
 
     @Override
     public Node<V> visit(NullNode<V> nullNode, Bytes path) {
-        return NULL_NODE_RESULT;
+        return NULL_NODE;
     }
 
+    protected Node<V> maybeFlatten(BranchNode<V> branchNode) {
+        final Optional<Byte> onlyChildIndex = findOnlyChild(branchNode.getChildren());
+        // Many children => return node as is
+        if (!onlyChildIndex.isPresent()) {
+            return branchNode;
+        }
+        // One child => merge with child: replace the path of the only child and return it
+        final Node<V> onlyChild = branchNode.child(onlyChildIndex.get());
+        final Bytes completePath = Bytes.concatenate(branchNode.getPath(), Bytes.of(onlyChildIndex.get()), onlyChild.getPath());
+        return onlyChild.replacePath(completePath);
+    }
+
+    private Optional<Byte> findOnlyChild(final List<Node<V>> children) {
+        Optional<Byte> onlyChildIndex = Optional.empty();
+        for (int i = 0; i < children.size(); ++i) {
+            if (children.get(i) != NULL_NODE) {
+                if (onlyChildIndex.isPresent()) {
+                    return Optional.empty();
+                }
+                onlyChildIndex = Optional.of((byte) i);
+            }
+        }
+        return onlyChildIndex;
+    }
 }

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrieTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/ethereum/trie/verkle/SimpleVerkleTrieTest.java
@@ -119,15 +119,12 @@ public class SimpleVerkleTrieTest {
         byte index2 = key2.get(31);
         trie.put(key1, value1);
         trie.put(key2, value2);
-        Node<Bytes32> root = trie.getRoot();
-        assertThat(root).as("Many values trie is a BranchNode").isInstanceOf(BranchNode.class);
-        BranchNode<Bytes32> branchRoot = (BranchNode<Bytes32>) root;
         trie.remove(key1);
         assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-        assertThat(branchRoot.child(index1)).as("Child at index of first key is a NullNode").isInstanceOf(NullNode.class);
+        assertThat(trie.getRoot()).as("One value => flatten to one LeafNode").isInstanceOf(LeafNode.class);
         trie.remove(key2);
         assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-        assertThat(branchRoot.child(index2)).as("Child at index of second key is a NullNode").isInstanceOf(NullNode.class);
+        assertThat(trie.getRoot()).as("No value => back to NullNode root").isInstanceOf(NullNode.class);
     }
 
     @Test
@@ -141,15 +138,12 @@ public class SimpleVerkleTrieTest {
         byte index2 = key2.get(0);
         trie.put(key1, value1);
         trie.put(key2, value2);
-        Node<Bytes32> root = trie.getRoot();
-        assertThat(root).as("Many values trie's root is a BranchNode").isInstanceOf(BranchNode.class);
-        BranchNode<Bytes32> branchRoot = (BranchNode<Bytes32>) root;
         trie.remove(key1);
         assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-        assertThat(branchRoot.child(index1)).as("Child at index of first key is a NullNode").isInstanceOf(NullNode.class);
+        assertThat(trie.getRoot()).as("One value => flatten to one LeafNode").isInstanceOf(LeafNode.class);
         trie.remove(key2);
         assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-        assertThat(branchRoot.child(index2)).as("Child at index of second key is a NullNode").isInstanceOf(NullNode.class);
+        assertThat(trie.getRoot()).as("No value => back to NullNode root").isInstanceOf(NullNode.class);
     }
 
     @Test
@@ -163,15 +157,12 @@ public class SimpleVerkleTrieTest {
         byte index2 = key2.get(1);
         trie.put(key1, value1);
         trie.put(key2, value2);
-        Node<Bytes32> root = trie.getRoot();
-        assertThat(root).as("Many values trie's root is a BranchNode").isInstanceOf(BranchNode.class);
-        BranchNode<Bytes32> branchRoot = (BranchNode<Bytes32>) root;
         trie.remove(key1);
         assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-        assertThat(branchRoot.child(index1)).as("Child at index of first key is a NullNode").isInstanceOf(NullNode.class);
+        assertThat(trie.getRoot()).as("One value => flatten to one LeafNode").isInstanceOf(LeafNode.class);
         trie.remove(key2);
         assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-        assertThat(branchRoot.child(index2)).as("Child at index of second key is a NullNode").isInstanceOf(NullNode.class);
+        assertThat(trie.getRoot()).as("No value => back to NullNode root").isInstanceOf(NullNode.class);
     }
 
     @Test
@@ -183,14 +174,9 @@ public class SimpleVerkleTrieTest {
         Bytes32 value2 = Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
         Bytes32 key3 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
         Bytes32 value3 = Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
-        byte index1 = key1.get(1);
         trie.put(key1, value1);
         trie.put(key2, value2);
         trie.put(key3, value3);
-        Node<Bytes32> root = trie.getRoot();
-        assertThat(root).as("Many values trie's root is a BranchNode").isInstanceOf(BranchNode.class);
-        BranchNode<Bytes32> branchRoot = (BranchNode<Bytes32>) root;
-        assertThat(branchRoot.child(index1)).as("Child at index of first key is a LeafNode").isInstanceOf(LeafNode.class);
         trie.remove(key3);
         assertThat(trie.get(key3)).as("Make sure value is deleted").isEqualTo(Optional.empty());
         assertThat(trie.get(key2)).as("Retrieve second value").isEqualTo(Optional.of(value2));
@@ -199,6 +185,30 @@ public class SimpleVerkleTrieTest {
         assertThat(trie.get(key1)).as("Retrieve first value").isEqualTo(Optional.of(value1));
         trie.remove(key1);
         assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
-        assertThat(branchRoot.child(index1)).as("Child at index of first key is a NullNode").isInstanceOf(NullNode.class);
+    }
+
+    @Test
+    public void testDeleteThreeValuesWithFlattening() throws Exception {
+        SimpleVerkleTrie<Bytes32, Bytes32> trie = new SimpleVerkleTrie<Bytes32, Bytes32>();
+        Bytes32 key1 = Bytes32.fromHexString("0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+        Bytes32 value1 = Bytes32.fromHexString("0x1000000000000000000000000000000000000000000000000000000000000000");
+        Bytes32 key2 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddee");
+        Bytes32 value2 = Bytes32.fromHexString("0x0200000000000000000000000000000000000000000000000000000000000000");
+        Bytes32 key3 = Bytes32.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff");
+        Bytes32 value3 = Bytes32.fromHexString("0x0300000000000000000000000000000000000000000000000000000000000000");
+        trie.put(key1, value1);
+        trie.put(key2, value2);
+        trie.put(key3, value3);
+        assertThat(trie.getRoot().getPath()).as("Initial extension path").isEqualTo(Bytes.fromHexString("0x00"));
+        trie.remove(key1);
+        assertThat(trie.get(key1)).as("Make sure value is deleted").isEqualTo(Optional.empty());
+        assertThat(trie.getRoot().getPath()).as("First flatten: extension path").isEqualTo(Bytes.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccdd"));
+        assertThat(trie.get(key2)).as("Retrieve second value").isEqualTo(Optional.of(value2));
+        trie.remove(key2);
+        assertThat(trie.get(key2)).as("Make sure value is deleted").isEqualTo(Optional.empty());
+        assertThat(trie.getRoot().getPath()).as("Second flatten: extension path").isEqualTo(Bytes.fromHexString("0x00ff112233445566778899aabbccddeeff00112233445566778899aabbccddff"));
+        assertThat(trie.get(key3)).as("Retrieve first value").isEqualTo(Optional.of(value3));
+        trie.remove(key3);
+        assertThat(trie.get(key3)).as("Make sure value is deleted").isEqualTo(Optional.empty());
     }
 }


### PR DESCRIPTION
Currently, RemoveVisitor nullified LeafNodes and that was it. Although all operations including commitments are correct, putting and removing a value could potentially lead to a different trie than it initially was due to splitting extensions.

This PR implements the reverse operation to branching in an extension: flattening. This way, the Trie structure is minimal and does not depend on the history of operations, but only on the key-value mapping.